### PR TITLE
Regexp bug meant you could only tag one-character tags

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Attribute::Exporter.
 
+0.02 2014-07-
+    - Regexp bug meant you could only have tags of one character
+
 0.01  Thu Jul 19 13:44:38 2012
 	- original version; created by h2xs 1.23 with options
 		-b 5.6.0 -AX Attribute::Exporter

--- a/lib/Attribute/Exporter.pm
+++ b/lib/Attribute/Exporter.pm
@@ -208,7 +208,7 @@ sub _MODIFY_ATTRIBUTES {
 	my $export_ok_attr = delete($attrs{export_ok});
 	my @export_tag_attrs;
 	for my $attr (keys(%attrs)) {
-		if (my ($tag) = $attr =~ m/^export_tag\(([^)])\)$/) {
+		if (my ($tag) = $attr =~ m/^export_tag\(([^)]+)\)$/) {
 			if ($tag eq 'DEFAULT' || $tag eq 'OK') {
 				carp "using $tag as an export tag clobbers internal $tag";
 			}


### PR DESCRIPTION
Hi,

I couldn't get the export_tag stuff to work, until I spotted the missing '+' in the regexp.

If you don't want to maintain this module (any more), I'd be happy to take it on, and do a release. My PAUSE id is NEILB -- let me know if you want instructions for transferring permissions.

Cheers,
Neil
